### PR TITLE
switched to an active rustjwt repo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,7 +125,7 @@ dependencies = [
  "r2d2 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "r2d2-diesel 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.7.3 (git+https://github.com/DevHeap/reqwest)",
- "rusty_jwt 1.0.0 (git+https://github.com/DevHeap/rusty_jwt)",
+ "rustwt 1.0.1 (git+https://github.com/Richterrettich/rustwt)",
  "serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -651,9 +651,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "rusty_jwt"
-version = "1.0.0"
-source = "git+https://github.com/DevHeap/rusty_jwt#5a9db53633a1ae418577bf5a23e40154519df5f4"
+name = "rustwt"
+version = "1.0.1"
+source = "git+https://github.com/Richterrettich/rustwt#4d6d5b31b2f6fa41558b84bfca442853090fba23"
 dependencies = [
  "base64 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1063,7 +1063,7 @@ dependencies = [
 "checksum reqwest 0.7.3 (git+https://github.com/DevHeap/reqwest)" = "<none>"
 "checksum rustc-demangle 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "aee45432acc62f7b9a108cc054142dac51f979e69e71ddce7d6fc7adf29e817e"
 "checksum rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "c5f5376ea5e30ce23c03eb77cbe4962b988deead10910c372b226388b594c084"
-"checksum rusty_jwt 1.0.0 (git+https://github.com/DevHeap/rusty_jwt)" = "<none>"
+"checksum rustwt 1.0.1 (git+https://github.com/Richterrettich/rustwt)" = "<none>"
 "checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
 "checksum schannel 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7554288337c1110e34d7a2433518d889374c1de1a45f856b7bcddb03702131fc"
 "checksum scheduled-thread-pool 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d9fbe48ead32343b76f544c85953bf260ed39219a8bbbb62cd85f6a00f9644f"

--- a/lib/circles-common/Cargo.toml
+++ b/lib/circles-common/Cargo.toml
@@ -25,5 +25,5 @@ git = "https://github.com/DevHeap/hyper"
 [dependencies.reqwest]
 git = "https://github.com/DevHeap/reqwest"
 
-[dependencies.rusty_jwt]
-git = "https://github.com/DevHeap/rusty_jwt"
+[dependencies.rustwt]
+git = "https://github.com/Richterrettich/rustwt"

--- a/lib/circles-common/src/lib.rs
+++ b/lib/circles-common/src/lib.rs
@@ -31,7 +31,7 @@ extern crate log;
 extern crate hyper;
 extern crate reqwest;
 extern crate openssl;
-extern crate rusty_jwt as jwt;
+extern crate rustwt as jwt;
 extern crate base64;
 
 #[macro_use]


### PR DESCRIPTION
As was discovered in https://github.com/Richterrettich/rusty_jwt/pull/6, we've been using an abandoned fork of frank_jwt, so we are switching to an [active repo](https://github.com/Richterrettich/rustwt)

Using a git repo dependency for now until the version with our Google Firebase tokens support patch is not published  on crates.io

I've tested everything with the currently disabled API integration tests, all good. 